### PR TITLE
Add portal transformation success events

### DIFF
--- a/src/main/java/cn/qihuang02/portaltransform/compat/kubejs/KubeJSPlugin.java
+++ b/src/main/java/cn/qihuang02/portaltransform/compat/kubejs/KubeJSPlugin.java
@@ -12,9 +12,11 @@ import cn.qihuang02.portaltransform.compat.kubejs.components.ItemPredicateCompon
 import cn.qihuang02.portaltransform.compat.kubejs.components.LevelComponent;
 import cn.qihuang02.portaltransform.compat.kubejs.components.TimeComponent;
 import cn.qihuang02.portaltransform.compat.kubejs.components.WeatherComponent;
+import cn.qihuang02.portaltransform.compat.kubejs.event.PortalTransformKubeEvents;
 import cn.qihuang02.portaltransform.compat.kubejs.recipe.ItemTransformKubeRecipe;
 import cn.qihuang02.portaltransform.compat.kubejs.schema.PortalItemTransformRecipeSchema;
 import cn.qihuang02.portaltransform.recipe.Recipes;
+import dev.latvian.mods.kubejs.event.EventGroupRegistry;
 import dev.latvian.mods.kubejs.recipe.schema.RecipeComponentFactoryRegistry;
 import dev.latvian.mods.kubejs.recipe.schema.RecipeFactoryRegistry;
 import dev.latvian.mods.kubejs.recipe.schema.RecipeSchemaRegistry;
@@ -28,6 +30,11 @@ public class KubeJSPlugin implements dev.latvian.mods.kubejs.plugin.KubeJSPlugin
         if (bindings.type().isServer()) {
             bindings.add("Byproduct", ByproductsBinding.class);
         }
+    }
+
+    @Override
+    public void registerEvents(@NotNull EventGroupRegistry registry) {
+        registry.register(PortalTransformKubeEvents.GROUP);
     }
 
     @Override

--- a/src/main/java/cn/qihuang02/portaltransform/compat/kubejs/event/PortalItemTransformedKubeEvent.java
+++ b/src/main/java/cn/qihuang02/portaltransform/compat/kubejs/event/PortalItemTransformedKubeEvent.java
@@ -1,0 +1,80 @@
+package cn.qihuang02.portaltransform.compat.kubejs.event;
+
+import cn.qihuang02.portaltransform.event.PortalItemTransformedEvent;
+import cn.qihuang02.portaltransform.recipe.ItemTransform.EnergyRequirement.EnergyPlan;
+import cn.qihuang02.portaltransform.recipe.ItemTransformRecipe;
+import dev.latvian.mods.kubejs.level.KubeLevelEvent;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Server-side KubeJS event fired after an item successfully transforms inside a portal.
+ */
+public class PortalItemTransformedKubeEvent implements KubeLevelEvent {
+    private final PortalItemTransformedEvent event;
+
+    public PortalItemTransformedKubeEvent(@NotNull PortalItemTransformedEvent event) {
+        this.event = event;
+    }
+
+    @Override
+    public ServerLevel getLevel() {
+        return event.getLevel();
+    }
+
+    public ResourceKey<Level> getCurrentDimension() {
+        return event.getCurrentDimension();
+    }
+
+    public ResourceKey<Level> getTargetDimension() {
+        return event.getTargetDimension();
+    }
+
+    public Vec3 getPosition() {
+        return event.getPosition();
+    }
+
+    public ItemStack getInput() {
+        return event.getOriginalStack();
+    }
+
+    public ItemStack getResult() {
+        return event.getResultStack();
+    }
+
+    public ItemStack getRemaining() {
+        return event.getRemainingStack();
+    }
+
+    public boolean wasInsertedIntoContainer() {
+        return event.wasInsertedIntoContainer();
+    }
+
+    public List<ItemStack> getByproducts() {
+        return event.getByproducts();
+    }
+
+    public ItemTransformRecipe getRecipe() {
+        return event.getRecipe();
+    }
+
+    public ResourceLocation getRecipeId() {
+        return event.getRecipeId();
+    }
+
+    public Optional<EnergyPlan> getEnergyPlan() {
+        return event.getEnergyPlan();
+    }
+
+    public PortalItemTransformedEvent asNeoEvent() {
+        return event;
+    }
+}

--- a/src/main/java/cn/qihuang02/portaltransform/compat/kubejs/event/PortalTransformKubeEvents.java
+++ b/src/main/java/cn/qihuang02/portaltransform/compat/kubejs/event/PortalTransformKubeEvents.java
@@ -1,0 +1,18 @@
+package cn.qihuang02.portaltransform.compat.kubejs.event;
+
+import cn.qihuang02.portaltransform.event.PortalItemTransformedEvent;
+import dev.latvian.mods.kubejs.event.EventGroup;
+import dev.latvian.mods.kubejs.event.EventHandler;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * KubeJS event definitions for PortalTransform.
+ */
+public interface PortalTransformKubeEvents {
+    EventGroup GROUP = EventGroup.of("PortalTransformEvents");
+    EventHandler ITEM_TRANSFORMED = GROUP.server("itemTransformed", () -> PortalItemTransformedKubeEvent.class);
+
+    static void postItemTransformed(@NotNull PortalItemTransformedEvent event) {
+        ITEM_TRANSFORMED.post(new PortalItemTransformedKubeEvent(event));
+    }
+}

--- a/src/main/java/cn/qihuang02/portaltransform/event/PortalItemTransformedEvent.java
+++ b/src/main/java/cn/qihuang02/portaltransform/event/PortalItemTransformedEvent.java
@@ -1,0 +1,124 @@
+package cn.qihuang02.portaltransform.event;
+
+import cn.qihuang02.portaltransform.recipe.ItemTransform.EnergyRequirement.EnergyPlan;
+import cn.qihuang02.portaltransform.recipe.ItemTransform.EnergyRequirement.EnergyTarget;
+import cn.qihuang02.portaltransform.recipe.ItemTransformRecipe;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
+import net.neoforged.bus.api.Event;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Fired when an {@link ItemEntity} successfully transforms via a portal item transform recipe.
+ */
+public class PortalItemTransformedEvent extends Event {
+    private final ServerLevel level;
+    private final ResourceKey<Level> targetDimension;
+    private final ItemEntity itemEntity;
+    private final Vec3 position;
+    private final ItemStack originalStack;
+    private final ItemStack resultStack;
+    private final ItemStack remainingStack;
+    private final List<ItemStack> byproducts;
+    private final ItemTransformRecipe recipe;
+    private final ResourceLocation recipeId;
+    private final Optional<EnergyPlan> energyPlan;
+
+    public PortalItemTransformedEvent(@NotNull ServerLevel level,
+                                      @NotNull ResourceKey<Level> targetDimension,
+                                      @NotNull ItemEntity itemEntity,
+                                      @NotNull Vec3 position,
+                                      @NotNull ItemStack originalStack,
+                                      @NotNull ItemStack resultStack,
+                                      @NotNull ItemStack remainingStack,
+                                      @NotNull List<ItemStack> byproducts,
+                                      @NotNull ItemTransformRecipe recipe,
+                                      @NotNull ResourceLocation recipeId,
+                                      @NotNull Optional<EnergyPlan> energyPlan) {
+        this.level = Objects.requireNonNull(level, "level");
+        this.targetDimension = Objects.requireNonNull(targetDimension, "targetDimension");
+        this.itemEntity = Objects.requireNonNull(itemEntity, "itemEntity");
+        this.position = Objects.requireNonNull(position, "position");
+        this.originalStack = originalStack.copy();
+        this.resultStack = resultStack.copy();
+        this.remainingStack = remainingStack.copy();
+        this.byproducts = List.copyOf(byproducts.stream().map(ItemStack::copy).toList());
+        this.recipe = Objects.requireNonNull(recipe, "recipe");
+        this.recipeId = Objects.requireNonNull(recipeId, "recipeId");
+        this.energyPlan = copyEnergyPlan(Objects.requireNonNull(energyPlan, "energyPlan"));
+    }
+
+    public ServerLevel getLevel() {
+        return level;
+    }
+
+    public ResourceKey<Level> getCurrentDimension() {
+        return level.dimension();
+    }
+
+    public ResourceKey<Level> getTargetDimension() {
+        return targetDimension;
+    }
+
+    public ItemEntity getItemEntity() {
+        return itemEntity;
+    }
+
+    public Vec3 getPosition() {
+        return position;
+    }
+
+    public BlockPos getBlockPos() {
+        return BlockPos.containing(position);
+    }
+
+    public ItemStack getOriginalStack() {
+        return originalStack.copy();
+    }
+
+    public ItemStack getResultStack() {
+        return resultStack.copy();
+    }
+
+    public ItemStack getRemainingStack() {
+        return remainingStack.copy();
+    }
+
+    public boolean wasInsertedIntoContainer() {
+        return remainingStack.isEmpty();
+    }
+
+    public List<ItemStack> getByproducts() {
+        return byproducts.stream().map(ItemStack::copy).toList();
+    }
+
+    public ItemTransformRecipe getRecipe() {
+        return recipe;
+    }
+
+    public ResourceLocation getRecipeId() {
+        return recipeId;
+    }
+
+    public Optional<EnergyPlan> getEnergyPlan() {
+        return copyEnergyPlan(energyPlan);
+    }
+
+    private static Optional<EnergyPlan> copyEnergyPlan(Optional<EnergyPlan> plan) {
+        return plan.map(original -> new EnergyPlan(
+                original.targets().stream()
+                        .map(target -> new EnergyTarget(target.pos(), target.direction(), target.amount()))
+                        .toList()
+        ));
+    }
+}

--- a/src/main/java/cn/qihuang02/portaltransform/event/PortalTransformHandler.java
+++ b/src/main/java/cn/qihuang02/portaltransform/event/PortalTransformHandler.java
@@ -2,9 +2,12 @@ package cn.qihuang02.portaltransform.event;
 
 import cn.qihuang02.portaltransform.PortalTransform;
 import cn.qihuang02.portaltransform.component.Components;
+import cn.qihuang02.portaltransform.compat.kubejs.event.PortalTransformKubeEvents;
 import cn.qihuang02.portaltransform.recipe.ItemTransform.Byproducts;
 import cn.qihuang02.portaltransform.recipe.ItemTransform.Biomes;
 import cn.qihuang02.portaltransform.recipe.ItemTransform.EnergyRequirement;
+import cn.qihuang02.portaltransform.recipe.ItemTransform.EnergyRequirement.EnergyPlan;
+import cn.qihuang02.portaltransform.recipe.ItemTransform.EnergyRequirement.EnergyTarget;
 import cn.qihuang02.portaltransform.recipe.ItemTransform.Weather;
 import cn.qihuang02.portaltransform.recipe.ItemTransformRecipe;
 import cn.qihuang02.portaltransform.recipe.Recipes;
@@ -14,6 +17,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.entity.Entity;
@@ -26,12 +30,18 @@ import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.fml.ModList;
 import net.neoforged.neoforge.event.entity.EntityTravelToDimensionEvent;
+import net.neoforged.neoforge.common.NeoForge;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 
 @EventBusSubscriber(
         modid = PortalTransform.MODID,
@@ -114,7 +124,7 @@ public class PortalTransformHandler {
                     return;
                 }
             }
-            transformItem(itemEntity, level, recipe);
+            transformItem(itemEntity, level, match, event.getDimension());
         } else {
             itemEntity.discard();
         }
@@ -214,15 +224,19 @@ public class PortalTransformHandler {
                 .orElse(true);
     }
 
-    private static void transformItem(ItemEntity itemEntity, ServerLevel level, ItemTransformRecipe recipe) {
+    private static void transformItem(ItemEntity itemEntity, ServerLevel level, RecipeMatch match, ResourceKey<Level> targetDimKey) {
         Objects.requireNonNull(itemEntity, "ItemEntity cannot be null");
         Objects.requireNonNull(level, "Level cannot be null");
-        Objects.requireNonNull(recipe, "Recipe cannot be null");
+        Objects.requireNonNull(match, "Recipe match cannot be null");
+
+        ItemTransformRecipe recipe = match.holder().value();
+        ResourceLocation recipeId = match.holder().id();
 
         BlockPos spawnPos = itemEntity.blockPosition();
         Vec3 pos = itemEntity.position();
         Vec3 motion = itemEntity.getDeltaMovement();
         int originalInputCount = itemEntity.getItem().getCount();
+        ItemStack inputCopy = itemEntity.getItem().copy();
         RandomSource random = level.random;
 
         ItemStack recipeResult = recipe.getResultItem(level.registryAccess());
@@ -239,6 +253,7 @@ public class PortalTransformHandler {
         } else {
             outputStack = recipeResult.copyWithCount(originalInputCount);
         }
+        ItemStack producedStack = outputStack.copy();
 
         ItemStack remainingOutput = InventoryUtil.tryPlaceInNearbyInv(level, spawnPos, outputStack);
 
@@ -249,38 +264,73 @@ public class PortalTransformHandler {
         }
 
         // Process byproducts
-        spawnByproducts(level, pos, motion, recipe, originalInputCount, random);
+        List<ItemStack> producedByproducts = spawnByproducts(level, pos, motion, recipe, originalInputCount, random);
+
+        PortalItemTransformedEvent transformedEvent = new PortalItemTransformedEvent(
+                level,
+                targetDimKey,
+                itemEntity,
+                pos,
+                inputCopy,
+                producedStack,
+                remainingOutput,
+                producedByproducts,
+                recipe,
+                recipeId,
+                copyEnergyPlan(match.energyPlan())
+        );
+
+        NeoForge.EVENT_BUS.post(transformedEvent);
+
+        if (ModList.get().isLoaded("kubejs")) {
+            PortalTransformKubeEvents.postItemTransformed(transformedEvent);
+        }
     }
 
-    private static void spawnByproducts(ServerLevel level, Vec3 pos, Vec3 motion, ItemTransformRecipe recipe, int originalInputCount, RandomSource random) {
-        recipe.getByproducts().ifPresent(byproducts -> {
-            // Group byproducts by type to batch spawn them
-            var byproductCounts = new java.util.HashMap<ItemStack, Integer>();
-            
-            for (Byproducts definition : byproducts) {
-                for (int i = 0; i < originalInputCount; i++) {
-                    definition.getResult(random).ifPresent(byproductStack -> {
-                        // Find existing entry or create new one
-                        ItemStack existingKey = byproductCounts.keySet().stream()
-                                .filter(stack -> ItemStack.isSameItemSameComponents(stack, byproductStack))
-                                .findFirst()
-                                .orElse(null);
-                                
-                        if (existingKey != null) {
-                            byproductCounts.put(existingKey, byproductCounts.get(existingKey) + byproductStack.getCount());
-                        } else {
-                            byproductCounts.put(byproductStack.copy(), byproductStack.getCount());
-                        }
-                    });
-                }
+    private static Optional<EnergyPlan> copyEnergyPlan(Optional<EnergyPlan> originalPlan) {
+        return originalPlan.map(plan -> new EnergyPlan(
+                plan.targets().stream()
+                        .map(target -> new EnergyTarget(target.pos(), target.direction(), target.amount()))
+                        .toList()
+        ));
+    }
+
+    private static List<ItemStack> spawnByproducts(ServerLevel level, Vec3 pos, Vec3 motion, ItemTransformRecipe recipe, int originalInputCount, RandomSource random) {
+        Optional<List<Byproducts>> byproductsOpt = recipe.getByproducts();
+        if (byproductsOpt.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        HashMap<ItemStack, Integer> byproductCounts = new HashMap<>();
+        for (Byproducts definition : byproductsOpt.get()) {
+            for (int i = 0; i < originalInputCount; i++) {
+                definition.getResult(random).ifPresent(byproductStack -> {
+                    ItemStack existingKey = byproductCounts.keySet().stream()
+                            .filter(stack -> ItemStack.isSameItemSameComponents(stack, byproductStack))
+                            .findFirst()
+                            .orElse(null);
+
+                    if (existingKey != null) {
+                        byproductCounts.put(existingKey, byproductCounts.get(existingKey) + byproductStack.getCount());
+                    } else {
+                        byproductCounts.put(byproductStack.copy(), byproductStack.getCount());
+                    }
+                });
             }
-            
-            // Spawn batched byproducts
-            byproductCounts.forEach((stack, totalCount) -> {
-                ItemStack spawnStack = stack.copyWithCount(totalCount);
-                spawnItemByproduct(level, pos, motion, spawnStack, random);
-            });
+        }
+
+        if (byproductCounts.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<ItemStack> producedStacks = new ArrayList<>(byproductCounts.size());
+        byproductCounts.forEach((stack, totalCount) -> {
+            ItemStack spawnStack = stack.copyWithCount(totalCount);
+            spawnItemByproduct(level, pos, motion, spawnStack, random);
+            producedStacks.add(spawnStack.copy());
         });
+
+        return producedStacks;
     }
 
     private static void spawnItemByproduct(ServerLevel level, Vec3 pos, Vec3 motion, @NotNull ItemStack byproductStack, RandomSource random) {


### PR DESCRIPTION
## Summary
- emit a new `PortalItemTransformedEvent` when item transformations succeed, including results and byproduct details
- post the event on the NeoForge bus and forward it to new KubeJS event hooks
- update the KubeJS plugin to register the portal transform event group for scripts

## Testing
- `bash gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68d0bcc77d5c832aa24e7f1d83d04d35